### PR TITLE
feat: add canvas zoom controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **Multi-usuário**: Vários jogadores por sala
 - **Reconexão automática** em caso de queda
 - **Interface responsiva** para desktop e mobile
+- **Zoom**: Aproximar/Afastar o canvas com Alt + ↑ / Alt + ↓
 
 ## 🛠️ Tecnologias
 

--- a/src/main/resources/META-INF/resources/styles.css
+++ b/src/main/resources/META-INF/resources/styles.css
@@ -303,6 +303,7 @@ body {
     padding: 1rem;
     background: #f0f2f5;
     position: relative;
+    transform-origin: top left;
 }
 
 #drawingCanvas {


### PR DESCRIPTION
## Summary
- add keyboard and wheel zoom controls for the drawing canvas
- adjust coordinate calculations so strokes remain aligned after zoom
- document new Alt + ArrowUp/ArrowDown shortcuts

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e637962f08327840e23e68a5df74c