### PR TITLE
Persist floating images for new room members

### DIFF
--- a/src/main/java/com/desenho/model/Room.java
+++ b/src/main/java/com/desenho/model/Room.java
@@ -1,7 +1,9 @@
 package com.desenho.model;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
@@ -9,12 +11,14 @@ public class Room {
     private String roomId;
     private Set<String> players;
     private String canvasData;
+    private Map<String, DrawingMessage> floatingImages;
     private long lastUpdate;
     
     public Room(String roomId) {
         this.roomId = roomId;
         this.players = ConcurrentHashMap.newKeySet();
         this.canvasData = null;
+        this.floatingImages = new ConcurrentHashMap<>();
         this.lastUpdate = System.currentTimeMillis();
     }
     
@@ -31,9 +35,19 @@ public class Room {
     public boolean isEmpty() {
         return players.isEmpty();
     }
-    
+
     public void updateCanvas(String canvasData) {
         this.canvasData = canvasData;
+        updateTimestamp();
+    }
+
+    public void addFloatingImage(DrawingMessage image) {
+        floatingImages.put(image.getImageId(), image);
+        updateTimestamp();
+    }
+
+    public void removeFloatingImage(String imageId) {
+        floatingImages.remove(imageId);
         updateTimestamp();
     }
     
@@ -50,6 +64,9 @@ public class Room {
     
     public String getCanvasData() { return canvasData; }
     public void setCanvasData(String canvasData) { this.canvasData = canvasData; }
+
+    public Map<String, DrawingMessage> getFloatingImages() { return floatingImages; }
+    public void setFloatingImages(Map<String, DrawingMessage> floatingImages) { this.floatingImages = floatingImages; }
     
     public long getLastUpdate() { return lastUpdate; }
     public void setLastUpdate(long lastUpdate) { this.lastUpdate = lastUpdate; }

--- a/src/main/java/com/desenho/service/RoomService.java
+++ b/src/main/java/com/desenho/service/RoomService.java
@@ -65,6 +65,9 @@ public class RoomService {
     public void addFloatingImage(String roomId, DrawingMessage image) {
         Room room = getRoom(roomId);
         if (room != null) {
+            if (image.getImageId() == null || image.getImageId().isBlank()) {
+                image.setImageId(java.util.UUID.randomUUID().toString());
+            }
             room.addFloatingImage(image);
         }
     }

--- a/src/main/java/com/desenho/service/RoomService.java
+++ b/src/main/java/com/desenho/service/RoomService.java
@@ -1,7 +1,9 @@
 package com.desenho.service;
 
 import com.desenho.model.Room;
+import com.desenho.model.DrawingMessage;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Random;
@@ -58,6 +60,25 @@ public class RoomService {
         if (room != null) {
             room.updateCanvas(canvasData);
         }
+    }
+
+    public void addFloatingImage(String roomId, DrawingMessage image) {
+        Room room = getRoom(roomId);
+        if (room != null) {
+            room.addFloatingImage(image);
+        }
+    }
+
+    public void removeFloatingImage(String roomId, String imageId) {
+        Room room = getRoom(roomId);
+        if (room != null) {
+            room.removeFloatingImage(imageId);
+        }
+    }
+
+    public Collection<DrawingMessage> getFloatingImages(String roomId) {
+        Room room = getRoom(roomId);
+        return room != null ? room.getFloatingImages().values() : java.util.Collections.emptyList();
     }
     
     private String generateRoomCode() {

--- a/src/main/java/com/desenho/websocket/DrawingWebSocket.java
+++ b/src/main/java/com/desenho/websocket/DrawingWebSocket.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 import jakarta.websocket.*;
 import jakarta.websocket.server.ServerEndpoint;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ServerEndpoint("/drawing")
@@ -273,10 +272,7 @@ public class DrawingWebSocket {
             return;
         }
         
-        // Store image in room state
-        if (message.getImageId() == null || message.getImageId().isBlank()) {
-            message.setImageId(UUID.randomUUID().toString());
-        }
+        // Store image in room state (service will assign an ID if needed)
         roomService.addFloatingImage(roomId, message);
 
         // Broadcast to all users in the room (including sender for confirmation)

--- a/src/main/java/com/desenho/websocket/DrawingWebSocket.java
+++ b/src/main/java/com/desenho/websocket/DrawingWebSocket.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import jakarta.websocket.*;
 import jakarta.websocket.server.ServerEndpoint;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ServerEndpoint("/drawing")
@@ -273,6 +274,9 @@ public class DrawingWebSocket {
         }
         
         // Store image in room state
+        if (message.getImageId() == null || message.getImageId().isBlank()) {
+            message.setImageId(UUID.randomUUID().toString());
+        }
         roomService.addFloatingImage(roomId, message);
 
         // Broadcast to all users in the room (including sender for confirmation)

--- a/src/main/java/com/desenho/websocket/DrawingWebSocket.java
+++ b/src/main/java/com/desenho/websocket/DrawingWebSocket.java
@@ -132,6 +132,11 @@ public class DrawingWebSocket {
         } else {
             // logger.info("No existing canvas data found for room " + roomId);
         }
+
+        // Send existing floating images to the new player
+        for (DrawingMessage img : roomService.getFloatingImages(roomId)) {
+            sendMessage(session, img);
+        }
         
         // Broadcast updated player list
         broadcastPlayerList(roomId);
@@ -267,6 +272,9 @@ public class DrawingWebSocket {
             return;
         }
         
+        // Store image in room state
+        roomService.addFloatingImage(roomId, message);
+
         // Broadcast to all users in the room (including sender for confirmation)
         Map<Session, String> sessions = roomSessions.get(roomId);
         if (sessions != null) {
@@ -279,11 +287,14 @@ public class DrawingWebSocket {
             // logger.warning("No sessions found for room " + roomId);
         }
     }
-    
+
     private void removeFloatingImage(DrawingMessage message, Session sender) {
         String roomId = message.getRoomId();
         // logger.info("Removing floating image from room: " + roomId + " imageId: " + message.getImageId());
-        
+
+        // Remove from room state
+        roomService.removeFloatingImage(roomId, message.getImageId());
+
         // Broadcast to all users in the room
         broadcastToRoom(roomId, message, sender);
     }


### PR DESCRIPTION
## Summary
- Track floating images in room state
- Sync stored images to new participants on join
- Persist image add/remove events via RoomService

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Network is unreachable)*
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa7361f0c8327854d6a60b8dd538c