### PR TITLE
Fix WebSocket message size configuration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,9 +5,8 @@
 quarkus.http.port=${PORT:8080}
 
 # WebSocket configuration
-quarkus.websockets.max-frame-size=1048576
-quarkus.websockets.max-binary-message-size=1048576
-quarkus.websockets.max-text-message-size=1048576
+quarkus.http.websocket-server.max-frame-size=1048576
+quarkus.http.websocket-server.max-message-size=1048576
 
 # CORS configuration for development
 quarkus.http.cors=true


### PR DESCRIPTION
## Summary
- configure Quarkus WebSocket frame and message size limits using proper `quarkus.http.websocket-server` properties

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.8.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bcee00148327832ea37b5be3a09e